### PR TITLE
Fixing empty jsonRPC.

### DIFF
--- a/flox/launcher.py
+++ b/flox/launcher.py
@@ -12,7 +12,7 @@ class Launcher(object):
     Launcher python plugin base
     """
 
-    def __call__(self, debug=None):
+    def __init__(self, debug=None):
         self.run(debug)
 
     def run(self, debug=None):


### PR DESCRIPTION
As answer to my https://github.com/Garulf/Flox/issues/10:

Reverting the commit https://github.com/Garulf/Flox/commit/01bb1daf3de78c3699862ef62b751fed78e3efe1.
Changing `__call__` back to `__init__`, solves the problem.